### PR TITLE
feat: implement one to many between users and tiers

### DIFF
--- a/migrations/20250220152929-add-type-field-to-tiers.js
+++ b/migrations/20250220152929-add-type-field-to-tiers.js
@@ -1,0 +1,16 @@
+'use strict';
+const tableName = 'tiers';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn(tableName, 'type', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: 'individual',
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn(tableName, 'type');
+  },
+};

--- a/migrations/20250220153849-create-user-tiers-table.js
+++ b/migrations/20250220153849-create-user-tiers-table.js
@@ -1,0 +1,51 @@
+'use strict';
+const tableName = 'user_tiers';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable(tableName, {
+      id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+      },
+      user_uuid: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'uuid',
+        },
+      },
+      tier_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'tiers',
+          key: 'id',
+        },
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn('NOW'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn('NOW'),
+      },
+    });
+
+    await queryInterface.removeColumn('users', 'tier_id');
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable(tableName);
+
+    await queryInterface.addColumn('users', 'tier_id', {
+      type: Sequelize.UUID,
+      allowNull: false,
+    });
+  },
+};

--- a/src/enums/limits.enum.ts
+++ b/src/enums/limits.enum.ts
@@ -1,0 +1,4 @@
+export enum LimitType {
+  INDIVIDUAL = 'individual',
+  BUSINESS = 'business',
+}

--- a/src/models/tier.model.ts
+++ b/src/models/tier.model.ts
@@ -1,5 +1,6 @@
 import { Table, Model, Column, DataType, HasMany } from 'sequelize-typescript';
-import { UserModel } from './user.model';
+import { UserTierModel } from './user-tier.model';
+import { LimitType } from 'src/enums/limits.enum';
 
 @Table({
   timestamps: true,
@@ -20,8 +21,15 @@ export class TierModel extends Model {
   })
   zones: string[];
 
-  @HasMany(() => UserModel)
-  users: UserModel[];
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+    defaultValue: LimitType.INDIVIDUAL,
+  })
+  type: LimitType;
+
+  @HasMany(() => UserTierModel)
+  userTiers: UserTierModel[];
 
   @Column({
     type: DataType.DATE,

--- a/src/models/user-tier.model.ts
+++ b/src/models/user-tier.model.ts
@@ -1,0 +1,67 @@
+import {
+  Table,
+  Model,
+  Column,
+  DataType,
+  ForeignKey,
+  BelongsTo,
+} from 'sequelize-typescript';
+import { UserModel } from './user.model';
+import { TierModel } from './tier.model';
+
+@Table({
+  timestamps: true,
+  tableName: 'user_tiers',
+  underscored: true,
+})
+export class UserTierModel extends Model {
+  @Column({
+    type: DataType.UUID,
+    allowNull: false,
+    primaryKey: true,
+    defaultValue: DataType.UUIDV4,
+  })
+  id: string;
+
+  @ForeignKey(() => UserModel)
+  @Column({
+    type: DataType.UUID,
+    allowNull: false,
+  })
+  userUuid: string;
+
+  @BelongsTo(() => UserModel, {
+    foreignKey: 'userUuid',
+    targetKey: 'uuid',
+    as: 'user',
+  })
+  user: UserModel;
+
+  @ForeignKey(() => TierModel)
+  @Column({
+    type: DataType.UUID,
+    allowNull: false,
+  })
+  tierId: string;
+
+  @BelongsTo(() => TierModel, {
+    foreignKey: 'tierId',
+    targetKey: 'id',
+    as: 'tier',
+  })
+  tier: TierModel;
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+    defaultValue: DataType.NOW,
+  })
+  createdAt: Date;
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+    defaultValue: DataType.NOW,
+  })
+  updatedAt: Date;
+}

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -1,13 +1,5 @@
-import {
-  Table,
-  Model,
-  Column,
-  DataType,
-  ForeignKey,
-  BelongsTo,
-  PrimaryKey,
-} from 'sequelize-typescript';
-import { TierModel } from './tier.model';
+import { Table, Model, Column, DataType, HasMany } from 'sequelize-typescript';
+import { UserTierModel } from './user-tier.model';
 
 @Table({
   timestamps: true,
@@ -22,15 +14,8 @@ export class UserModel extends Model {
   })
   uuid: string;
 
-  @ForeignKey(() => TierModel)
-  @Column({
-    type: DataType.UUIDV4,
-    allowNull: false,
-  })
-  tierId: string;
-
-  @BelongsTo(() => TierModel, 'tierId')
-  tier: TierModel;
+  @HasMany(() => UserTierModel)
+  userTiers: UserTierModel[];
 
   @Column({
     type: DataType.DATE,

--- a/src/modules/users/entities/user.entity.ts
+++ b/src/modules/users/entities/user.entity.ts
@@ -12,13 +12,9 @@ export class UserEntity {
   uuid: string;
 
   @Expose()
-  @ApiProperty()
-  tierId: string;
-
-  @Expose()
   @Type(() => TierEntity)
-  @ApiProperty({ type: TierEntity, required: false })
-  tier?: TierEntity;
+  @ApiProperty({ type: [TierEntity], required: false })
+  tiers?: TierEntity[];
 
   @Expose()
   @ApiProperty()


### PR DESCRIPTION
Added user_tiers model to allow the user to have more than one tier (individual and businessplan)
Added type field to tier to specify either individual or business
Updated models adn entities to adapt to this new relationship.